### PR TITLE
Refresh now checks if the file was already on the library, so if the filename doesn't include titleId, it wont be removed.

### DIFF
--- a/src/NsxLibraryManager/Services/TitleLibraryService.cs
+++ b/src/NsxLibraryManager/Services/TitleLibraryService.cs
@@ -697,6 +697,9 @@ public class TitleLibraryService(
             if (fileInfoService.TryGetFileInfoFromFileName(fileName.FileName, out var fileInfo))
             {
                 dirFiles.Add(fileName.FileName, fileInfo);
+            } else if (libraryFiles.TryGetValue(fileName.FileName, out var title))
+            {
+                dirFiles.Add(fileName.FileName, title.MapToLibraryTitleDto());
             }
         }
 


### PR DESCRIPTION
This change will allow to use refresh without removing files that don't have titleId, if they are already on the library, they wont be removed anymore. 