### PR TITLE
refresh-titledb-cli

### DIFF
--- a/src/NsxLibraryManager/Extensions/StartupFileDownloader.cs
+++ b/src/NsxLibraryManager/Extensions/StartupFileDownloader.cs
@@ -14,68 +14,93 @@ public static class StartupFileDownloader
         {
             Console.WriteLine($"Not downloading latest version of SqlTitleDb on Startup");
             return builder;
-        }        
-        var repoUrl = builder.Configuration.GetValue<string>($"{AppConstants.AppSettingsSectionName}:{AppConstants.AppSettingsSqlTitleDbRepository}");
+        }
+
+        await RefreshTitleDb(builder.Configuration);
+        return builder;
+    }
+
+    // Downloads titledb if the remote version differs from the local one, independent of the
+    // DownloadTitleDbOnStartup flag. Shared by the startup path and the --refresh-titledb CLI path.
+    // Returns true if titledb was updated. Throws on download/decompression failure so a scheduler
+    // invoking the CLI sees a non-zero exit code.
+    public static async Task<bool> RefreshTitleDb(IConfiguration configuration)
+    {
+        var repoUrl = configuration.GetValue<string>($"{AppConstants.AppSettingsSectionName}:{AppConstants.AppSettingsSqlTitleDbRepository}");
         if (repoUrl is null)
         {
             Console.WriteLine($"Titledb repository URL is missing in config.json");
-            return builder;
+            return false;
         }
-        var versionUrl= repoUrl.TrimEnd('/') + "/" + AppConstants.TitleDbVersionFile.TrimStart('/'); 
-        var titledbUrl= repoUrl.TrimEnd('/') + "/" + AppConstants.TitleDbFile.TrimStart('/'); 
+        var versionUrl = repoUrl.TrimEnd('/') + "/" + AppConstants.TitleDbVersionFile.TrimStart('/');
+        var titledbUrl = repoUrl.TrimEnd('/') + "/" + AppConstants.TitleDbFile.TrimStart('/');
 
         var versionsFile = Path.Combine(AppContext.BaseDirectory, AppConstants.ConfigDirectory, AppConstants.TitleDbVersionFile);
+        var compressedFilePath = Path.Combine(AppContext.BaseDirectory, AppConstants.DataDirectory, AppConstants.TitleDbFile);
+        var decompressedFilePath = Path.Combine(AppContext.BaseDirectory, AppConstants.DataDirectory, AppConstants.DefaultTitleDbName);
+        var tempFilePath = decompressedFilePath + ".tmp";
+
         var localVersion = string.Empty;
-        var remoteVersion = string.Empty;
-        var compressedFilePath = Path.Combine(AppContext.BaseDirectory, AppConstants.DataDirectory,
-            AppConstants.TitleDbFile);
-        var decompressedFilePath = Path.Combine(AppContext.BaseDirectory, AppConstants.DataDirectory,
-            AppConstants.DefaultTitleDbName);
         if (File.Exists(versionsFile))
         {
             localVersion = await File.ReadAllTextAsync(versionsFile);
         }
-        
+
+        var updated = false;
         try
         {
             using var httpClient = new HttpClient();
-            var request = httpClient.GetAsync(versionUrl);
-            var response = await request.Result.Content.ReadAsStringAsync();
-            remoteVersion = response.TrimEnd( '\r', '\n' );
+            var response = await httpClient.GetStringAsync(versionUrl);
+            var remoteVersion = response.TrimEnd('\r', '\n');
 
             if (remoteVersion.Length != 32)
             {
                 Console.WriteLine($"Invalid titledb version number from {versionUrl}, skipping download");
-                return builder;
+                return false;
             }
-            
-            if (localVersion != remoteVersion)
+
+            if (localVersion == remoteVersion)
             {
-                Console.WriteLine($"Downloading titledb version {remoteVersion}");
-                var fileBytes = await httpClient.GetByteArrayAsync(titledbUrl);
-                await File.WriteAllBytesAsync(compressedFilePath, fileBytes);
-                await using var compressedFileStream = new FileStream(compressedFilePath, FileMode.Open, FileAccess.Read);
-                await using var decompressedFileStream = new FileStream(decompressedFilePath, FileMode.Create, FileAccess.Write);
-                await using var gzipStream = new GZipStream(compressedFileStream, CompressionMode.Decompress);
+                Console.WriteLine($"Titledb already up to date (version {remoteVersion})");
+                return false;
+            }
+
+            Console.WriteLine($"Downloading titledb version {remoteVersion}");
+            var fileBytes = await httpClient.GetByteArrayAsync(titledbUrl);
+            await File.WriteAllBytesAsync(compressedFilePath, fileBytes);
+
+            // Decompress to a temp file, then atomically move it into place. A running app keeps
+            // serving from its already-open file handle until it restarts, rather than reading a
+            // half-written database mid-download.
+            await using (var compressedFileStream = new FileStream(compressedFilePath, FileMode.Open, FileAccess.Read))
+            await using (var decompressedFileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write))
+            await using (var gzipStream = new GZipStream(compressedFileStream, CompressionMode.Decompress))
+            {
                 await gzipStream.CopyToAsync(decompressedFileStream);
                 await gzipStream.FlushAsync();
-                await File.WriteAllTextAsync(versionsFile, remoteVersion);
             }
-            
+
+            File.Move(tempFilePath, decompressedFilePath, overwrite: true);
+            await File.WriteAllTextAsync(versionsFile, remoteVersion);
+            updated = true;
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error downloading file: {ex.Message}");
-            throw new InvalidOperationException("Required file could not be downloaded during startup", ex);
+            throw new InvalidOperationException("Required file could not be downloaded", ex);
         }
-
-        if (File.Exists(compressedFilePath))
+        finally
         {
-            File.Delete(compressedFilePath);
+            if (File.Exists(compressedFilePath))
+            {
+                File.Delete(compressedFilePath);
+            }
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
         }
 
-
-
-        return builder;
+        return updated;
     }
 }

--- a/src/NsxLibraryManager/Program.cs
+++ b/src/NsxLibraryManager/Program.cs
@@ -45,6 +45,15 @@ if (!Directory.Exists(iconPath))
     Directory.CreateDirectory(iconPath);
 }
 
+// One-shot titledb refresh: download-if-changed and exit, without starting the web host.
+// Meant to be driven by an external scheduler (cron, k8s CronJob, systemd timer).
+if (args.Contains("--refresh-titledb"))
+{
+    var updated = await StartupFileDownloader.RefreshTitleDb(initialConfig);
+    Console.WriteLine(updated ? "Titledb refresh complete." : "Titledb refresh: nothing to do.");
+    return;
+}
+
 var builder = WebApplication.CreateBuilder(args);
 
 // configuration.


### PR DESCRIPTION
Adds a `--refresh-titledb` argument that downloads the latest titledb (when the remote version differs) and exits, without starting the web host. Lets an external scheduler own the cadence — `NsxLibraryManager --refresh-titledb` from a cron job, k8s CronJob, or systemd timer — instead of relying on `DownloadTitleDbOnStartup` and a full app restart.

The download-if-changed logic is extracted out of the startup path into `RefreshTitleDb`, so the startup flag and the CLI call share it. The CLI path runs it ungated, so an explicit `--refresh-titledb` always checks for an update.

One correctness change came with it: the db is decompressed to a temp file and atomically renamed into place, rather than truncated and rewritten. `titledb.db` is a live SQLite file the app queries per request, so an in-place rewrite risks being read half-written mid-download. With the rename, a running instance keeps serving its open handle and picks up the new db on its next restart.

Exit code is 0 on success (updated or already current), non-zero on download failure, so a scheduler can detect failures.

Tested: a cold refresh (downloads, swaps in a 169 MB db, exits 0) and a repeat run (already up to date, no-op, exits 0).
