### PR TITLE
docker-workflow-dispatch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,9 @@ name: Docker
 on:
   push:
     tags: ['v*.*.*']
-    branches: ['add-fallbacks-regex']
   release:
     types: [created]
+  workflow_dispatch:
 env:
   REGISTRY: ghcr.io
   # Convert repository name to lowercase


### PR DESCRIPTION
Drops the leftover `branches: ['add-fallbacks-regex']` push trigger — that branch merged in #135 and the trigger has been sitting in the workflow since. Adds `workflow_dispatch` in its place, so a branch image can be built on demand from the Actions tab without hardcoding a branch name into the workflow each time. metadata-action already emits `type=ref,event=branch`, so a dispatched run tags the image by its branch name with no other changes.
