### PR TITLE
cli-options-parser

### DIFF
--- a/src/NsxLibraryManager/NsxLibraryManager.csproj
+++ b/src/NsxLibraryManager/NsxLibraryManager.csproj
@@ -26,6 +26,7 @@
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
+        <PackageReference Include="System.CommandLine" Version="2.0.10" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     </ItemGroup>
     

--- a/src/NsxLibraryManager/Program.cs
+++ b/src/NsxLibraryManager/Program.cs
@@ -1,3 +1,4 @@
+using System.CommandLine;
 using System.Diagnostics;
 using System.Text;
 using Common.Contracts;
@@ -23,6 +24,19 @@ using IRenamerService = NsxLibraryManager.Services.Interface.IRenamerService;
 
 Console.OutputEncoding = Encoding.UTF8;
 
+// Command-line flags, parsed once via System.CommandLine (parse-only — the web host still owns startup).
+var refreshTitledbOption = new Option<bool>("--refresh-titledb")
+{
+    Description = "Download titledb if the remote version changed, then exit without starting the web host."
+};
+var noBrowserOption = new Option<bool>("--no-browser")
+{
+    Description = "Do not open a browser window on startup."
+};
+var cli = new RootCommand("NsxLibraryManager") { refreshTitledbOption, noBrowserOption }.Parse(args);
+var refreshTitledb = cli.GetValue(refreshTitledbOption);
+var noBrowser = cli.GetValue(noBrowserOption);
+
 // if no config.json file exists, create one with default values
 var configFile = Path.Combine(AppContext.BaseDirectory, AppConstants.ConfigDirectory, AppConstants.ConfigFileName);
 
@@ -47,7 +61,7 @@ if (!Directory.Exists(iconPath))
 
 // One-shot titledb refresh: download-if-changed and exit, without starting the web host.
 // Meant to be driven by an external scheduler (cron, k8s CronJob, systemd timer).
-if (args.Contains("--refresh-titledb"))
+if (refreshTitledb)
 {
     var updated = await StartupFileDownloader.RefreshTitleDb(initialConfig);
     Console.WriteLine(updated ? "Titledb refresh complete." : "Titledb refresh: nothing to do.");
@@ -179,7 +193,6 @@ app.EnsureDatabaseMigrated<NsxLibraryDbContext>();
 
 if (app.Environment.IsProduction())
 {
-    var noBrowser = args.Contains("--no-browser");
     var isWindows = OperatingSystem.IsWindows();
     if (!noBrowser && isWindows)
     {


### PR DESCRIPTION
Follows up on your merge note on #136 — swaps the ad-hoc `args.Contains` checks for a proper parser.

`--refresh-titledb` and `--no-browser` are now typed options on a `RootCommand`, parsed once into bools. Parse-only (no `Invoke`), so `WebApplication` still owns startup and unrecognized host args (`--urls`, `--environment`, etc.) are ignored rather than erroring. The bare-flag UX is unchanged, so any scheduled `--refresh-titledb` invocation keeps working exactly as before.

Dependency: System.CommandLine 2.0.10 — the stable release, not a preview. Microsoft's official CLI parser, trim/AOT-friendly.

Grows cleanly: a third flag is one `Option` plus one line, and if you ever want subcommands or `--help` output it's already the right foundation.
